### PR TITLE
Added Button Functionality + Default Sheet Styling

### DIFF
--- a/module.json
+++ b/module.json
@@ -28,7 +28,8 @@
     "/scripts/settings.js"
   ],
   "styles": [
-    "styles/main.css"
+    "styles/main.css",
+    "styles/media.css"
   ],
   "url": "https://github.com/Syrious/foundryvtt-sheet-only",
   "manifest": "https://github.com/Syrious/foundryvtt-sheet-only/releases/download/latest/module.json",

--- a/scripts/addControlButtons.js
+++ b/scripts/addControlButtons.js
@@ -13,6 +13,11 @@ export function addControlButtons(sheetContainer) {
         collapseButton.on("click", function () {
             $('#collapse-actor-select i').toggleClass('hidden');
             $('.sheet-only-actor-list').toggleClass('collapse');
+            if($('.sheet-only-actor-list.collapse')){
+                localStorage.setItem("collapsed-actor-select", "true");
+            } else{
+                localStorage.setItem("collapsed-actor-select", "false");
+            }
         });
         increaseButton.on("click", function () {
             scaleFactor += 0.1;
@@ -31,8 +36,13 @@ export function addControlButtons(sheetContainer) {
             ui.menu.items.logout.onClick();
         })
     });
-
     sheetContainer.append(uiElement);
+
+    if(localStorage.getItem("collapsed-actor-select") === 'true'){
+        $('#collapse-actor-select i').toggleClass('hidden');
+        $('.sheet-only-actor-list').toggleClass('collapse');
+    }
+
 }
 
 function setZoom(sheetContainer) {

--- a/scripts/addControlButtons.js
+++ b/scripts/addControlButtons.js
@@ -1,18 +1,23 @@
 let scaleFactor = 1;
 
-export function addZoomButtons(sheetContainer) {
+export function addControlButtons(sheetContainer) {
     const uiElement = $(`<div class="button-container"></div>`);
 
     uiElement.load("modules/sheet-only/templates/buttons.html", function () {
+        const collapseButton = uiElement.find("#collapse-actor-select")
         const increaseButton = uiElement.find("#increase-font");
         const decreaseButton = uiElement.find("#decrease-font");
-        const resetButton = uiElement.find("#reset-font");
+        const resetButton    = uiElement.find("#reset-font");
+        const logoutButton   = uiElement.find("#so-log-out");
 
+        collapseButton.on("click", function () {
+            $('#collapse-actor-select i').toggleClass('hidden');
+            $('.sheet-only-actor-list').toggleClass('collapse');
+        });
         increaseButton.on("click", function () {
             scaleFactor += 0.1;
             setZoom(sheetContainer);
         });
-
         decreaseButton.on("click", function () {
             scaleFactor = Math.max(scaleFactor - 0.1, 0.1);
             setZoom(sheetContainer);
@@ -22,6 +27,9 @@ export function addZoomButtons(sheetContainer) {
             scaleFactor = 1;
             setZoom(sheetContainer);
         });
+        logoutButton.on("click", function(){
+            ui.menu.items.logout.onClick();
+        })
     });
 
     sheetContainer.append(uiElement);

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -32,6 +32,8 @@ Hooks.on('renderActorSheet', async (app, html) => {
         app.element.addClass('sheet-only-sheet');
         $('.sheet-only-container').append(app.element);
         $(".window-resizable-handle").hide();
+
+        getTokenizerImage();
     }
 })
 
@@ -72,7 +74,7 @@ function rebuildActorList() {
     let actorList = $('.sheet-only-actor-list');
 
     actorList.empty();
-
+    
     let actorElements = getActorElements();
 
     if (actorElements.length > 1) {
@@ -90,17 +92,32 @@ function getOwnedActors() {
 function getActorElements() {
     let actors = getOwnedActors();
     return actors.map(actor => {
-            return $('<div>')
-                // .text(actor.name)
-                .append($('<img>').attr('src', actor.img).attr('width', '75').attr('height', '75'))
-                .click(() => {
-                    if (currentSheet) {
-                        currentSheet.close();
-                    }
-                    currentSheet = actor.sheet.render(true);
-                });
+        return $('<div>')
+            // .text(actor.name)
+            .append($('<img>').attr('src', actor.img).attr('width', '75').attr('height', '75'))
+            .click(() => {
+                if (currentSheet) {
+                    currentSheet.close();
+                }
+                currentSheet = actor.sheet.render(true);
+            });
         }
     );
+}
+
+function getTokenizerImage(){
+    let actors = getOwnedActors();
+    actors.map(actor => {
+        let actorImg = actor.img;
+        let sheet = $('#ActorSheet5eCharacter-Actor-' + actor._id)[0];
+        if(sheet !== undefined){
+            if(actorImg.includes('tokenizer') 
+            && actorImg.includes('Avatar')){
+                actorImg = actorImg.replace('Avatar', 'Token');
+                $('.sheet-only-container .sheet-header img.profile')[0].src = actorImg;
+            }
+        }
+    });
 }
 
 function hideElements() {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -93,8 +93,8 @@ function getActorElements() {
     let actors = getOwnedActors();
     return actors.map(actor => {
         return $('<div>')
-            .text(actor.name)
-            .append($('<img>').attr('src', actor.img).attr('width', 'auto').attr('height', 'auto'))
+            //.text(actor.name)
+            .append($('<img>').attr('src', actor.img))
             .click(() => {
                 if (currentSheet) {
                     currentSheet.close();

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -93,8 +93,8 @@ function getActorElements() {
     let actors = getOwnedActors();
     return actors.map(actor => {
         return $('<div>')
-            // .text(actor.name)
-            .append($('<img>').attr('src', actor.img).attr('width', '75').attr('height', '75'))
+            .text(actor.name)
+            .append($('<img>').attr('src', actor.img).attr('width', 'auto').attr('height', 'auto'))
             .click(() => {
                 if (currentSheet) {
                     currentSheet.close();

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,5 +1,5 @@
 import {addFontSizeButtons} from "./addFontSizeButtons.js";
-import {addZoomButtons} from "./addZoomButtons.js";
+import {addControlButtons} from "./addControlButtons.js";
 
 let currentSheet = null; // Track the currently open sheet
 Hooks.on('setup', async () => {
@@ -66,7 +66,7 @@ function setupContainer() {
         addFontSizeButtons(sheetContainer);
     }else{
         console.log("Adding zoom buttons");
-        addZoomButtons(sheetContainer);
+        addControlButtons(sheetContainer);
     }
 
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -16,7 +16,7 @@
     width: 100vw;
     height: 100vh;
     justify-items: flex-start;
-    overflow: auto;
+    overflow: hidden;
 }
 
 .sheet-only-container > .button-container {
@@ -148,4 +148,27 @@
     text-align: left;
     font-size: 16px;
     min-width: 60px;
+}
+
+.dnd5e.sheet.actor.character.sheet-only-sheet{
+    min-width: none;
+}
+.dnd5e.sheet.actor.character.sheet-only-sheet .tab.attributes{
+    overflow: auto;
+}
+.dnd5e.sheet.actor.character.sheet-only-sheet .sheet-navigation{
+    flex: 0 0 60px;
+    flex-wrap: wrap;
+}
+.dnd5e.sheet.actor.character.sheet-only-sheet .sheet-navigation .item{
+    flex: 1 0 25%;
+}
+.dnd5e.sheet.actor.character.sheet-only-sheet .sheet-header .attributes .attribute{
+    flex: 1 0 33%;
+}
+.dnd5e.sheet.actor.character.sheet-only-sheet .skills-list{
+    flex: auto;
+}
+.dnd5e.sheet.actor.character.sheet-only-sheet .center-pane{
+    flex: 1 0 100%;
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -36,7 +36,7 @@
 .sheet-only-actor-list {
     display: flex;
     flex-direction: column;
-    background-color: rgb(66 67 83 / 90%);
+    background-color: rgb(0 0 0 / 90%);
     justify-items: flex-start;
     padding: 5px;
     gap: 3px;
@@ -45,12 +45,14 @@
     z-index: 200;
     height: 100vh;
     width: 33vw;
+    border-right: 10px solid rgb(68 68 68 / 90%);
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
     transition: all 250ms;
     overflow: auto;
 }
 .sheet-only-actor-list.collapse{
-    width: 0;
-    padding: 0;
+    margin-left: -33%;
 }
 .sheet-only-actor-list img{
     border: none;

--- a/styles/main.css
+++ b/styles/main.css
@@ -36,11 +36,20 @@
 .sheet-only-actor-list {
     display: flex;
     flex-direction: column;
-    background-color: #424353;
+    background-color: rgb(66 67 83 / 90%);
     justify-items: flex-start;
     padding: 5px;
     gap: 3px;
     flex-shrink: 0;
+    position: absolute;
+    z-index: 200;
+    height: 100vh;
+    width: 33vw;
+    transition: all 250ms;
+}
+.sheet-only-actor-list.collapse{
+    width: 0;
+    padding: 0;
 }
 .sheet-only-actor-list img{
     border: none;
@@ -151,7 +160,7 @@
 }
 
 .dnd5e.sheet.actor.character.sheet-only-sheet{
-    min-width: none;
+    min-width: auto;
 }
 .dnd5e.sheet.actor.character.sheet-only-sheet .tab.attributes{
     overflow: auto;
@@ -171,4 +180,5 @@
 }
 .dnd5e.sheet.actor.character.sheet-only-sheet .center-pane{
     flex: 1 0 100%;
+    overflow-y: visible;
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -46,6 +46,7 @@
     height: 100vh;
     width: 33vw;
     transition: all 250ms;
+    overflow: auto;
 }
 .sheet-only-actor-list.collapse{
     width: 0;
@@ -162,6 +163,12 @@
 .dnd5e.sheet.actor.character.sheet-only-sheet{
     min-width: auto;
 }
+.dnd5e.sheet.actor.character.sheet-only-sheet .sheet-header img.profile{
+    border: none;
+}
+.dnd5e.sheet.actor.character.sheet-only-sheet .sheet-header .header-details{
+    border-left: 2px groove #eeede0;
+}
 .dnd5e.sheet.actor.character.sheet-only-sheet .tab.attributes{
     overflow: auto;
 }
@@ -174,6 +181,9 @@
 }
 .dnd5e.sheet.actor.character.sheet-only-sheet .sheet-header .attributes .attribute{
     flex: 1 0 33%;
+    border:none;
+    border-bottom: 2px groove #eeede0;
+    border-left: 2px groove #eeede0;
 }
 .dnd5e.sheet.actor.character.sheet-only-sheet .skills-list{
     flex: auto;

--- a/styles/main.css
+++ b/styles/main.css
@@ -23,7 +23,7 @@
     display: flex;
     flex-direction: row;
     position: fixed;
-    bottom: 10px;
+    bottom: 20px;
     right: 10px;
     z-index: 9999; /* Higher z-index value */
 }

--- a/styles/media.css
+++ b/styles/media.css
@@ -1,0 +1,13 @@
+@media only screen and (max-width: 575px){
+    .dnd5e.sheet.actor.character.sheet-only-sheet .item-detail.item-quantity{
+        display: none;
+    }
+    .dnd5e.sheet.actor.character.sheet-only-sheet .spell-target{
+        display: none;
+    }
+}
+@media only screen and (max-width: 615px){
+    .dnd5e.sheet.actor.character.sheet-only-sheet .inventory-filters .currency h3{
+        display: none;
+    }
+}

--- a/styles/media.css
+++ b/styles/media.css
@@ -1,3 +1,11 @@
+@media only screen and (max-width: 500px){
+    .dnd5e.sheet.actor.character.sheet-only-sheet .item-detail.item-weight{
+        display: none;
+    }
+    .dnd5e.sheet.actor.character.sheet-only-sheet .spell-school{
+        display: none;
+    }
+}
 @media only screen and (max-width: 575px){
     .dnd5e.sheet.actor.character.sheet-only-sheet .item-detail.item-quantity{
         display: none;

--- a/templates/buttons.html
+++ b/templates/buttons.html
@@ -3,8 +3,13 @@
 <head>
 </head>
     <body>
+        <button id="collapse-actor-select" class="button">
+            <i class="fa-solid fa-circle-chevron-left"></i>
+            <i class="fa-solid fa-circle-chevron-right hidden"></i>
+        </button>
         <button id="increase-font" class="button"><i class="fas fa-plus"></i></button>
         <button id="decrease-font" class="button"><i class="fas fa-minus"></i></button>
         <button id="reset-font" class="button"><i class="fas fa-undo"></i></button>
+        <button id="so-log-out" class="button"><i class="fas fa-sign-out-alt"></i></button>
     </body>
 </html>


### PR DESCRIPTION
As described in #5 the sheet is functional, but a bit cumbersome when used on a narrow screen smaller than 768px or so. I have changed some stlyings to break the flex of the char sheet when required, removed the fixed sheet size and added button functionality to the control buttons in the bottom right:
- Collapse Button: This button (first in the controls) collapses the owned actor row. This allows the user to toggle the owned actor section (which is now layered over the character sheet to save space). The toggled status is saved in LS, auto-collapsing the owned actor section when it was collapsed by the user.
- Logout Button: I've noticed that loging out of Foundry wasn't possible with the module enabled which can only be bypassed by clearing LS and cache. A logout button is now provided as the last control element.

![image](https://github.com/Syrious/foundryvtt-sheet-only/assets/29397572/088ba66e-abc8-4a05-bb90-0c18df2ab89f)

The owned actor section now also has scroll behaviour when overflow is present, enabling many owned actors.

In addition, many QoL improvements have been made for a responsive display of the character sheet.