### PR TITLE
Forces re-rendering of sheet on resize event

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -304,3 +304,8 @@ function setCurrentActorTokenAsControlled() {
         activeTokens[0].control({releaseOthers: true})
     }
 }
+
+addEventListener("resize", onResize);
+function onResize(event) {
+    currentSheet.render(true)
+}


### PR DESCRIPTION
This is a very dumb way of [forcing](https://foundryvtt.com/api/classes/client.ActorSheet.html#render) the re-rendering of the sheet when the size of the window changes (e.g. device is rotated).  
Not stupid if it works I guess
PoC:

https://github.com/Syrious/foundryvtt-sheet-only/assets/17499836/391d4bda-c040-47c6-a4aa-82b0e01655ad

https://github.com/Syrious/foundryvtt-sheet-only/assets/17499836/7629bc86-4bcc-4c0b-896d-a3c4e593a509

