### PR TITLE
Set display of the board to none when canvas: hidden

### DIFF
--- a/scripts/canvasHider.js
+++ b/scripts/canvasHider.js
@@ -3,8 +3,8 @@ export function hideCanvas(){
 }
 
 function checkDnd5e() {
-    if(game.system ==='dnd5e' || document.getElementById('board')){
+  if (game.system === 'dnd5e' || document.getElementById('board')) {
         // Hide the canvas
-        document.getElementById('board').style.display = 'none';
-    }
+    document.body.classList.add("hidden-canvas");
+  }
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -82,6 +82,10 @@
     overflow: auto;
 }
 
+body.hidden-canvas canvas#board {
+    display: none !important;
+}
+
 .sheet-only-chat.fullscreen {
     width: 100%;
 }


### PR DESCRIPTION
I found-out that the previous solution was not working at all. Because at the time the script to set the #board to display: none was being run, the board has not been initiated at all.

Handled this via css instead of js so we can ensure no matter how many times the board is created/modified/distroyed by other modules the display will always be set to none  

|   | Before  | After  |
|---|---|---|
| css (Pay attention to the display property) | ![image](https://github.com/user-attachments/assets/94fa9ac0-942d-4bb6-aa58-01de8a9200c5)  | ![image](https://github.com/user-attachments/assets/97701bce-e7d8-466c-abef-95ada5a9df87)  |
| App (With character sheet closed)  | ![image](https://github.com/user-attachments/assets/3ca78803-6077-47eb-92cd-fe39a658c466)  |  ![image](https://github.com/user-attachments/assets/e3ff0d06-3c98-43e8-ab95-391955354492) |