### PR TITLE
Character Sheet CSS Responsiveness improvements

### DIFF
--- a/styles/dnd5e.css
+++ b/styles/dnd5e.css
@@ -34,6 +34,18 @@
 
 @media (max-width: 800px) {
     /** General Responsive Changes */
+    .dnd5e.sheet.actor.character.sheet-only-sheet .header-details .summary {
+        height: auto;
+    }
+    .dnd5e.sheet.actor.character.sheet-only-sheet .header-details .summary > li {
+        min-width: 80px;
+        min-width: min-content;
+        height: auto;
+    }
+    .dnd5e.sheet.actor.character.sheet-only-sheet .header-details .summary > li input {
+        min-width: 80px;
+    }
+
     .dnd5e.sheet.actor.character.sheet-only-sheet .sheet-navigation.tabs {
         column-gap: 24px;
         row-gap: 5px;

--- a/styles/dnd5e.css
+++ b/styles/dnd5e.css
@@ -33,8 +33,15 @@
 }
 
 @media (max-width: 800px) {
-    .dnd5e.sheet.actor.character.sheet-only-sheet .sheet-body {
-        padding-top: 5px;
+    /** General Responsive Changes */
+    .dnd5e.sheet.actor.character.sheet-only-sheet .sheet-navigation.tabs {
+        column-gap: 24px;
+        row-gap: 5px;
+        padding-bottom: 10px;
+    }
+
+    .dnd5e.sheet.actor.character.sheet-only-sheet .sheet-navigation .item {
+        margin: 0;
     }
 
     /** Inventory Responsive Changes */

--- a/styles/dnd5e.css
+++ b/styles/dnd5e.css
@@ -8,23 +8,24 @@
 .dnd5e.sheet.actor.character.sheet-only-sheet .sheet-header .header-details{
     border-left: 2px groove #eeede0;
 }
-.dnd5e.sheet.actor.character.sheet-only-sheet .sheet-header {
-    zoom: 0.85;
-}
-.dnd5e.sheet.actor.character.sheet-only-sheet .tab.attributes {
-    zoom: 1.15
-}
 
-.dnd5e.sheet.actor.character.sheet-only-sheet .tab.inventory {
-    zoom: 1.1
-}
+@media (max-width: 800px) {
+    .dnd5e.sheet.actor.character.sheet-only-sheet .sheet-header {
+        zoom: 0.85;
+    }
 
-.dnd5e.sheet.actor.character.sheet-only-sheet .tab.features {
-    zoom: 1.1
-}
-
-.dnd5e.sheet.actor.character.sheet-only-sheet .tab.spellbook {
-    zoom: 1.1
+    .dnd5e.sheet.actor.character.sheet-only-sheet .tab.attributes {
+        zoom: 1.15
+    }
+    .dnd5e.sheet.actor.character.sheet-only-sheet .tab.inventory {
+        zoom: 1.1
+    }
+    .dnd5e.sheet.actor.character.sheet-only-sheet .tab.features {
+        zoom: 1.1
+    }
+    .dnd5e.sheet.actor.character.sheet-only-sheet .tab.spellbook {
+        zoom: 1.1
+    }
 }
 
 .dnd5e.sheet.actor.character.sheet-only-sheet .tab.attributes{

--- a/styles/dnd5e.css
+++ b/styles/dnd5e.css
@@ -75,6 +75,18 @@
         max-inline-size: 30px;
         height: 30px;
     }
+
+    /** Spellbook Responsive Changes */
+    .dnd5e.sheet.actor.character.sheet-only-sheet .spellbook-filters {
+        justify-content: flex-start;
+
+    }
+    .dnd5e.sheet.actor.character.sheet-only-sheet .spellbook-filters > .filter-list {
+        padding: 10px 0;
+        max-width: none;
+        flex-basis: 100%;
+        max-width: 500px;
+    }
 }
 
 .sheet-only-container .dnd5e.sheet.sheet-only-sheet .items-list {

--- a/styles/dnd5e.css
+++ b/styles/dnd5e.css
@@ -11,6 +11,22 @@
 .dnd5e.sheet.actor.character.sheet-only-sheet .sheet-header {
     zoom: 0.85;
 }
+.dnd5e.sheet.actor.character.sheet-only-sheet .tab.attributes {
+    zoom: 1.15
+}
+
+.dnd5e.sheet.actor.character.sheet-only-sheet .tab.inventory {
+    zoom: 1.1
+}
+
+.dnd5e.sheet.actor.character.sheet-only-sheet .tab.features {
+    zoom: 1.1
+}
+
+.dnd5e.sheet.actor.character.sheet-only-sheet .tab.spellbook {
+    zoom: 1.1
+}
+
 .dnd5e.sheet.actor.character.sheet-only-sheet .tab.attributes{
     overflow: auto;
 }

--- a/styles/dnd5e.css
+++ b/styles/dnd5e.css
@@ -8,6 +8,9 @@
 .dnd5e.sheet.actor.character.sheet-only-sheet .sheet-header .header-details{
     border-left: 2px groove #eeede0;
 }
+.dnd5e.sheet.actor.character.sheet-only-sheet .sheet-header {
+    zoom: 0.85;
+}
 .dnd5e.sheet.actor.character.sheet-only-sheet .tab.attributes{
     overflow: auto;
 }

--- a/styles/dnd5e.css
+++ b/styles/dnd5e.css
@@ -31,6 +31,52 @@
     flex: 1 0 100%;
     overflow-y: visible;
 }
+
+@media (max-width: 800px) {
+    .dnd5e.sheet.actor.character.sheet-only-sheet .sheet-body {
+        padding-top: 5px;
+    }
+
+    /** Inventory Responsive Changes */
+    .dnd5e.sheet.actor.character.sheet-only-sheet .currency {
+        margin: 0;
+        gap: 2px;
+    }
+
+    .dnd5e.sheet.actor.character.sheet-only-sheet .currency > h3 {
+        white-space: nowrap;
+    }
+    .dnd5e.sheet.actor.character.sheet-only-sheet .currency > .denomination {
+        margin-inline-start: 10px;
+        font-size: 0;
+    }
+    .dnd5e.sheet.actor.character.sheet-only-sheet .currency > .denomination::after {
+        font-size: 12px;
+        content: "";
+    }
+    .dnd5e.sheet.actor.character.sheet-only-sheet .currency > .pp::after {
+        content: "P";
+    }
+    .dnd5e.sheet.actor.character.sheet-only-sheet .currency > .gp::after {
+        content: "G";
+    }
+    .dnd5e.sheet.actor.character.sheet-only-sheet .currency > .ep::after {
+        content: "E";
+    }
+    .dnd5e.sheet.actor.character.sheet-only-sheet .currency > .sp::after {
+        content: "S";
+    }
+    .dnd5e.sheet.actor.character.sheet-only-sheet .currency > .cp::after {
+        content: "C";
+    }
+
+    .dnd5e.sheet.actor.character.sheet-only-sheet .currency > input[type="text"] {
+        margin-left:0px;
+        max-inline-size: 30px;
+        height: 30px;
+    }
+}
+
 .sheet-only-container .dnd5e.sheet.sheet-only-sheet .items-list {
     list-style: none;
     margin: 0;

--- a/styles/main.css
+++ b/styles/main.css
@@ -7,6 +7,15 @@
 
 
 @media (max-width: 800px) {
+    /** Display jump fix */
+    #hud {
+        display: none;
+    }
+    .sheet-only-sheet {
+        margin-top: 0;
+        margin-bottom: 0;
+    }
+
     /* Item dialog improvements */
     .window-app {
         min-width: auto !important;

--- a/styles/main.css
+++ b/styles/main.css
@@ -5,6 +5,27 @@
     display: none !important;
 }
 
+
+@media (max-width: 800px) {
+    /* Item dialog improvements */
+    .window-app {
+        min-width: auto !important;
+        max-width: 100vw;
+    }
+    .window-app.sheet.item {
+        min-width: 100vw !important;
+        max-height: 85%;
+    }
+
+    .dnd5e.sheet .sheet-navigation {
+        gap: 10px;
+        justify-content: space-around;
+    }
+    .dnd5e.sheet .sheet-navigation .item {
+        margin: 0;
+    }
+}
+
 .sheet-only-sheet {
     position: relative;
     width: 100vw;


### PR DESCRIPTION
This MR does a bunch of QOL improvements at different parts of the legacy 5e character sheet.  

Namely:  
- Custom zoom values for different tabs and the header. Making it easier to make the most of the limited available space on mobile devices.   

| Before  | After  |
|---|---|
| ![image](https://github.com/user-attachments/assets/94e5f36e-1357-41c4-aa7a-1dbd70eb9ca4)  |  ![image](https://github.com/user-attachments/assets/1eeb1b9f-a485-42cc-8533-88ae2afadb0c) |

- Fixes to a few minor overflow/overlap issues here and there  
- Better UI for the navigation section  

| Before  | After  |
|---|---|
| ![image](https://github.com/user-attachments/assets/945b5983-4c7b-4a8d-9979-c5b48b20391c)  | ![image](https://github.com/user-attachments/assets/17d15578-a622-44ab-86f1-f7e74783f6d0)  |

- Better UI for spellbook and inventory headers

| Before  | After  |
|---|---|
| ![image](https://github.com/user-attachments/assets/f1b52bd3-7283-4f5a-8d54-c6d546463664)  | ![image](https://github.com/user-attachments/assets/234d6cc3-ee25-4aa6-83d5-edbc67b24e3d)  |
|  ![image](https://github.com/user-attachments/assets/8cebb6a5-9d93-4c26-b215-57a0510247b0) | ![image](https://github.com/user-attachments/assets/efca6c62-fb13-4212-880e-142ad1902a75)  |

- Make item dialogues 100% width so they won't overflow (We had this problem that when someone accidentally touched an items edit button, they didn't have access to the close button so they had to reload the whole page)
- Some misc. improvements to spacings