### PR TITLE
Improvements to actor list

### DIFF
--- a/scripts/actorStorage.js
+++ b/scripts/actorStorage.js
@@ -1,3 +1,7 @@
+export const actorStorage = {
+    current: null,
+} // The currently selected actor
+
 export function saveLastActorId(actorId) {
     game.settings.set("sheet-only", "lastActorId", actorId);
 }

--- a/scripts/actorsList.js
+++ b/scripts/actorsList.js
@@ -1,0 +1,75 @@
+import { actorStorage, saveLastActorId } from "./actorStorage.js";
+
+
+export function rebuildActorList() {
+    let actorList = $('.sheet-only-actor-list');
+
+    displayActorListButton();
+
+    actorList.empty();
+    let actorElements = getActorElements();
+
+    actorList.show();
+    actorElements.forEach(elem => actorList.append(elem));
+}
+
+export function displayActorListButton() {
+    const actorsListButton = $("#so-collapse-actor-select")
+    const ownedActors = getOwnedActors();
+    console.log(document.getElementById("so-collapse-actor-select"))
+    if(ownedActors.length > 1) {
+        actorsListButton.show();
+    } else {
+        actorsListButton.hide();
+    }
+}
+
+export function getOwnedActors() {
+    return game.actors.filter(actor => isActorOwnedByUser(actor));
+}
+
+export function isActorOwnedByUser(actor) {
+    return actor.ownership[game.user.id] === 3;
+}
+
+export function getActorElements() {
+    let actors = getOwnedActors();
+    return actors.map(actor => {
+            return $('<div>')
+                //.text(actor.name)
+                .append($('<img>').attr('src', actor.img))
+                .click(() => {
+                    switchToActor(actor);
+                    toggleActorList();
+                });
+        }
+    );
+}
+
+/**
+ * @param {Actor} actor
+ */
+export function switchToActor(actor) {
+    actorStorage.current = actor;
+    actor.sheet.render(true);
+
+    setCurrentActorTokenAsControlled();
+    saveLastActorId(actorStorage.current.id);
+}
+
+// Take control of the token of this actor (for targeting)
+function setCurrentActorTokenAsControlled() {
+    const activeTokens = actorStorage.current.getActiveTokens();
+    if (activeTokens.length > 0) {
+        activeTokens[0].control({releaseOthers: true})
+    }
+}
+
+export function toggleActorList() {
+    $('.sheet-only-actor-list').toggleClass('collapse');
+    if ($('.sheet-only-actor-list.collapse')) {
+        localStorage.setItem("collapsed-actor-select", "true");
+    } else {
+        localStorage.setItem("collapsed-actor-select", "false");
+    }
+}

--- a/scripts/addControlButtons.js
+++ b/scripts/addControlButtons.js
@@ -113,8 +113,6 @@ function setupDefaults() {
 }
 
 export function toggleActorList() {
-    $('#collapse-actor-select i').toggleClass('hidden');
-
     $('.sheet-only-actor-list').toggleClass('collapse');
     if ($('.sheet-only-actor-list.collapse')) {
         localStorage.setItem("collapsed-actor-select", "true");

--- a/scripts/addControlButtons.js
+++ b/scripts/addControlButtons.js
@@ -3,6 +3,7 @@ import {initDragListener, wasDragged} from "./drag.js";
 import {toggleFullscreen} from "./fullscreen.js";
 import {sheetOnlyPlusActive} from "./compatibility.js";
 import {moduleId} from "./settings.js";
+import { getOwnedActors } from "./main.js";
 
 export function addControlButtons(sheetContainer, increaseZoom, decreaseZoom, resetZoom) {
     const uiElement = $(`<div class="button-container so-draggable"></div>`);
@@ -20,6 +21,10 @@ export function addControlButtons(sheetContainer, increaseZoom, decreaseZoom, re
         const settingsButton = uiElement.find("#so-fvtt-settings");
         const menuButton = uiElement.find("#so-menu");
         const fullscreen = uiElement.find("#so-fullscreen");
+
+        if(getOwnedActors().length <= 1) {
+            collapseButton.remove()
+        }
 
         collapseButton.on("click", function () {
             if (wasDragged()) return;

--- a/scripts/addControlButtons.js
+++ b/scripts/addControlButtons.js
@@ -3,7 +3,7 @@ import {initDragListener, wasDragged} from "./drag.js";
 import {toggleFullscreen} from "./fullscreen.js";
 import {sheetOnlyPlusActive} from "./compatibility.js";
 import {moduleId} from "./settings.js";
-import { getOwnedActors } from "./main.js";
+import { displayActorListButton, toggleActorList } from "./actorsList.js";
 
 export function addControlButtons(sheetContainer, increaseZoom, decreaseZoom, resetZoom) {
     const uiElement = $(`<div class="button-container so-draggable"></div>`);
@@ -21,10 +21,6 @@ export function addControlButtons(sheetContainer, increaseZoom, decreaseZoom, re
         const settingsButton = uiElement.find("#so-fvtt-settings");
         const menuButton = uiElement.find("#so-menu");
         const fullscreen = uiElement.find("#so-fullscreen");
-
-        if(getOwnedActors().length <= 1) {
-            collapseButton.remove()
-        }
 
         collapseButton.on("click", function () {
             if (wasDragged()) return;
@@ -99,6 +95,8 @@ export function addControlButtons(sheetContainer, increaseZoom, decreaseZoom, re
             if (wasDragged()) return;
             toggleFullscreen();
         });
+
+        displayActorListButton()
     });
 
     sheetContainer.append(uiElement);
@@ -110,15 +108,6 @@ export function addControlButtons(sheetContainer, increaseZoom, decreaseZoom, re
 function setupDefaults() {
     $('#collapse-actor-select i').addClass('hidden');
     $('.sheet-only-actor-list').addClass('collapse');
-}
-
-export function toggleActorList() {
-    $('.sheet-only-actor-list').toggleClass('collapse');
-    if ($('.sheet-only-actor-list.collapse')) {
-        localStorage.setItem("collapsed-actor-select", "true");
-    } else {
-        localStorage.setItem("collapsed-actor-select", "false");
-    }
 }
 
 function toggleChat() {

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -1,4 +1,5 @@
-import {isSheetOnly, currentActor} from "./main.js";
+import { actorStorage } from "./actorStorage.js";
+import {isSheetOnly} from "./main.js";
 /* global game, Hooks*/
 
 
@@ -12,7 +13,7 @@ function setupApi() {
         plusCompatibility: "0.4.2",
 
         getCurrentActor: function () {
-            return currentActor;
+            return actorStorage.current;
         },
 
         isSheetOnly: function () {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -187,16 +187,11 @@ function rebuildActorList() {
 
     actorList.empty();
     let actorElements = getActorElements();
-    if (actorElements.length > 1) {
-
-        actorList.show();
-        actorElements.forEach(elem => actorList.append(elem));
-    } else {
-        actorList.hide();
-    }
+    actorList.show();
+    actorElements.forEach(elem => actorList.append(elem));
 }
 
-function getOwnedActors() {
+export function getOwnedActors() {
     return game.actors.filter(actor => isActorOwnedByUser(actor));
 }
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -165,7 +165,12 @@ function setupContainer() {
     const sheetContainer = $('<div>').addClass('sheet-only-container');
 
     $('body').append(sheetContainer);
-    sheetContainer.append($('<div>').addClass('sheet-only-actor-list').attr('id', 'sheet-only-actor-list'));
+    sheetContainer.append(
+      $('<div>')
+        .css({ 'padding-top': '40px' })
+        .addClass('sheet-only-actor-list')
+        .attr('id', 'sheet-only-actor-list')
+    );
 
     // Add control buttons depending on browser
     if (navigator.userAgent.indexOf("Firefox") !== -1) {

--- a/templates/buttons.html
+++ b/templates/buttons.html
@@ -4,11 +4,7 @@
 </head>
     <body>
         <div id="so-main-buttons">
-            <button id="so-collapse-actor-select" class="button">
-                <i class="fa-solid fa-circle-chevron-left"></i>
-                <i class="fa-solid fa-circle-chevron-right hidden"></i>
-            </button>
-
+            <button id="so-collapse-actor-select" class="button"><i class="fa-solid fa-user"></i></button>
             <button id="so-toggle-chat" class="button"><i class="fa-solid fa-comment-dots"></i></button>
             <button id="so-targeting" class="button"><i class="fa-solid fa-bullseye"></i></button>
             <button id="so-journal" class="button"><i class="fa-solid fa-book"></i></button>


### PR DESCRIPTION
This MR contains a few improvements to actors list.

- Add padding to actors list so they won't go beneath the icons at the top
- Show the button only if there are more than 1 actors available. Instead of showing an icon that doesn't do anything.
- Update the icon of the actor list button to `fa-user`  
- Some refactors.

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/09fe7bc6-e11e-4679-a652-802542f3ed0e)  | ![image](https://github.com/user-attachments/assets/dc471f73-b5ce-4d47-a246-53cdff022ac1) |  


This is specially useful after https://github.com/Syrious/foundryvtt-sheet-only/pull/57 is merged