### PR TITLE
SO Responsive Improvements

### DIFF
--- a/scripts/defaultZoom.js
+++ b/scripts/defaultZoom.js
@@ -4,12 +4,7 @@ export function increaseZoom() {
 
     scaleFactor += 0.1;
 
-    sheet.css({
-        'zoom': scaleFactor,
-        'transform-origin': 'top left',
-        'width': '100vw',
-        'height': '100vh'
-    });
+    sheet.css({ zoom: scaleFactor });
 }
 
 export function decreaseZoom() {
@@ -18,21 +13,11 @@ export function decreaseZoom() {
 
     scaleFactor = Math.max(scaleFactor - 0.1, 0.1);
 
-    sheet.css({
-        'zoom': scaleFactor,
-        'transform-origin': 'top left',
-        'width': '100vw',
-        'height': '100vh'
-    });
+    sheet.css({ zoom: scaleFactor });
 }
 
 export function resetZoom() {
     let sheet = $('.sheet-only-sheet');
 
-    sheet.css({
-        'zoom': 1,
-        'transform-origin': 'top left',
-        'width': '100vw',
-        'height': '100vh'
-    });
+    sheet.css({ zoom: 1 });
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -9,6 +9,8 @@
     position: relative;
     width: 100vw;
     height: 100vh;
+    height: 100dvh;
+    transform-origin: 'top left',
 }
 
 .sheet-only-container {
@@ -19,6 +21,7 @@
     top: 0;
     width: 100vw;
     height: 100vh;
+    height: 100dvh;
     justify-items: flex-start;
     overflow: hidden;
 }
@@ -121,6 +124,7 @@
     position: absolute;
     z-index: 99999;
     height: 100vh;
+    height: 100dvh;
     width: 33vw;
     max-width: 200px;
     border-right: 10px solid rgb(68 68 68 / 90%);

--- a/styles/main.css
+++ b/styles/main.css
@@ -23,15 +23,91 @@
     overflow: hidden;
 }
 
+.sheet-only-container > .button-container .button {
+    cursor: pointer;
+}
+
+.sheet-only-container > .button-container .button > i {
+    vertical-align: middle;
+}
+
+
 .sheet-only-container > .button-container {
     display: flex;
     flex-direction: row;
-    position: absolute;
     z-index: 99999;
 }
 
-.sheet-only-container > .button-container > .button {
-    cursor: pointer;
+#so-main-buttons, #so-settings-buttons, #so-menu-button {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+}
+
+@media (min-width: 800px) {
+    .sheet-only-container > .button-container {
+        position: absolute;
+    }
+}
+
+@media (max-width: 800px) {
+    .sheet-only-sheet {
+        padding-bottom: 55px;
+    }
+    .sheet-only-container {
+        padding-bottom: 55px;
+    }
+    .sheet-only-chat {
+        padding-top: 35px;
+        padding-bottom: 55px;
+    }
+    #so-settings-buttons {
+        display: flex !important;
+        position: fixed;
+        left: 0;
+        top: 0;
+        width: 100%;
+        max-width: 250px;
+    }
+    #so-main-buttons {
+        display: flex !important;
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: 50px;
+    }
+    #so-main-buttons > button {
+        height: 100%;
+    }
+    #so-main-buttons > button > i {
+        font-size: 24px;
+    }
+    #so-menu-button {
+        display: none;
+    }
+}
+
+.sheet-only-chat {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    position: absolute;
+    background-color: rgb(0 0 0 / 15%);
+    right: 0;
+    min-height: 30px;
+    max-height: 100%;
+    width: var(--sidebar-width);
+    z-index: 500;
+    border: #7a7971;
+    border-bottom-left-radius: 5px;
+    transition: all 250ms;
+    overflow: auto;
+}
+
+.sheet-only-chat.fullscreen {
+    width: 100%;
 }
 
 .sheet-only-actor-list {
@@ -56,34 +132,6 @@
 
 .sheet-only-actor-list.collapse {
     display: none !important;
-}
-
-#so-main-buttons, #so-settings-buttons, #so-menu-button {
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-start;
-    align-items: center;
-}
-
-.sheet-only-chat {
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
-    position: absolute;
-    background-color: rgb(0 0 0 / 15%);
-    right: 0;
-    min-height: 30px;
-    max-height: 100%;
-    width: var(--sidebar-width);
-    z-index: 500;
-    border: #7a7971;
-    border-bottom-left-radius: 5px;
-    transition: all 250ms;
-    overflow: auto;
-}
-
-.sheet-only-chat.fullscreen {
-    width: 100%;
 }
 
 .dragged {

--- a/styles/main.css
+++ b/styles/main.css
@@ -56,14 +56,16 @@
 
 @media (max-width: 800px) {
     .sheet-only-sheet {
-        padding-bottom: 55px;
+        margin-top: 0;
+        margin-bottom: 0;
+        padding-bottom: 53px;
     }
     .sheet-only-container {
-        padding-bottom: 55px;
+        padding-bottom: 53px;
     }
     .sheet-only-chat {
         padding-top: 35px;
-        padding-bottom: 55px;
+        padding-bottom: 53px;
     }
     #so-settings-buttons {
         display: flex !important;


### PR DESCRIPTION
General improvements to how sheet-only is being displayed on smaller displays. 
- Adding main buttons to the bottom of the screen so it's easier to reach/click
- Adding paddings to chat window and using `dvh` instead of `vh` so it takes the "browser addressbar/system statusbar" into account and things won't overflow on non-fullscreen mode.

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/d275b4ed-3942-4c2e-84b8-5132b4ccdaa1)  | ![image](https://github.com/user-attachments/assets/19828279-894f-40ca-b15f-9cfc3dfc12ae) |