### PR TITLE
Fix for closing character sheet when editing something (D&D 3.5 tested)

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -59,7 +59,7 @@ Hooks.once('ready', async function () {
 Hooks.on('renderActorSheet',
     /** @param {FormApplication|null} app */
     async (app) => {
-        if (!isSheetOnly()) {
+        if (!isSheetOnly() || currentSheet?.appId == app.appId) {
             return;
         }
 


### PR DESCRIPTION
Found an issue, at least on D&D 3.5 where updating a character sheet closes it and you have to go to another sheet and coming back.
Also this makes it more reactive not needing to reload again the character sheet completely :)